### PR TITLE
feat: add merge blockers detection and display

### DIFF
--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1,4 +1,4 @@
-use crate::model::{CiCheck, CiCheckState, CiState, Pr, ReviewState};
+use crate::model::{CiCheck, CiCheckState, CiState, MergeBlockers, Pr, ReviewState};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 static DEMO_TICK: AtomicU64 = AtomicU64::new(0);
@@ -29,6 +29,8 @@ struct DemoPrSpec {
     ci: CiProfile,
     is_draft: bool,
     is_viewer_author: bool,
+    /// Optional merge blockers for demo purposes.
+    blockers: Option<MergeBlockers>,
 }
 
 fn fnv1a_64(s: &str) -> u64 {
@@ -147,6 +149,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::Green,
             is_draft: false,
             is_viewer_author: false,
+            blockers: None,
         },
         DemoPrSpec {
             owner: "you-inc",
@@ -159,6 +162,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::Green,
             is_draft: false,
             is_viewer_author: true,
+            blockers: None,
         },
         DemoPrSpec {
             owner: "orbit",
@@ -171,6 +175,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::RedNew,
             is_draft: true,
             is_viewer_author: false,
+            blockers: None,
         },
         DemoPrSpec {
             owner: "windmill-labs",
@@ -183,6 +188,15 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::RedStuck,
             is_draft: false,
             is_viewer_author: false,
+            // Demo: has merge conflicts
+            blockers: Some(MergeBlockers {
+                has_conflicts: true,
+                required_approvals: Some(2),
+                current_approvals: 0,
+                required_checks: vec!["build".to_string(), "test".to_string()],
+                failing_required_checks: vec!["test".to_string()],
+                is_behind_base: false,
+            }),
         },
         DemoPrSpec {
             owner: "paperplane",
@@ -195,6 +209,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::RunningLong,
             is_draft: false,
             is_viewer_author: false,
+            blockers: None,
         },
         DemoPrSpec {
             owner: "acme-inc",
@@ -207,6 +222,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::RunningShort,
             is_draft: true,
             is_viewer_author: false,
+            blockers: None,
         },
         DemoPrSpec {
             owner: "honeycombio",
@@ -219,6 +235,15 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::Green,
             is_draft: false,
             is_viewer_author: false,
+            // Demo: needs more approvals
+            blockers: Some(MergeBlockers {
+                has_conflicts: false,
+                required_approvals: Some(2),
+                current_approvals: 1,
+                required_checks: vec![],
+                failing_required_checks: vec![],
+                is_behind_base: true,
+            }),
         },
         DemoPrSpec {
             owner: "orbit",
@@ -231,6 +256,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::Green,
             is_draft: false,
             is_viewer_author: true,
+            blockers: None,
         },
         DemoPrSpec {
             owner: "paperplane",
@@ -243,6 +269,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::NoCi,
             is_draft: false,
             is_viewer_author: false,
+            blockers: None,
         },
         DemoPrSpec {
             owner: "acme-inc",
@@ -255,6 +282,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::RunningLong,
             is_draft: false,
             is_viewer_author: false,
+            blockers: None,
         },
         DemoPrSpec {
             owner: "windmill-labs",
@@ -267,6 +295,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::Green,
             is_draft: false,
             is_viewer_author: false,
+            blockers: None,
         },
         DemoPrSpec {
             owner: "orbit",
@@ -279,6 +308,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::RedNew,
             is_draft: false,
             is_viewer_author: false,
+            blockers: None,
         },
         DemoPrSpec {
             owner: "paperplane",
@@ -291,6 +321,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::NoCi,
             is_draft: false,
             is_viewer_author: false,
+            blockers: None,
         },
         DemoPrSpec {
             owner: "honeycombio",
@@ -303,6 +334,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::Green,
             is_draft: false,
             is_viewer_author: false,
+            blockers: None,
         },
         DemoPrSpec {
             owner: "acme-inc",
@@ -315,6 +347,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::RedNew,
             is_draft: false,
             is_viewer_author: false,
+            blockers: None,
         },
         DemoPrSpec {
             owner: "windmill-labs",
@@ -327,6 +360,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::Green,
             is_draft: false,
             is_viewer_author: false,
+            blockers: None,
         },
         DemoPrSpec {
             owner: "paperplane",
@@ -339,6 +373,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
             ci: CiProfile::RunningLong,
             is_draft: false,
             is_viewer_author: false,
+            blockers: None,
         },
     ];
 
@@ -391,6 +426,7 @@ pub fn generate_demo_prs(now: i64, tick: u64) -> Vec<Pr> {
                 mergeable: Some("MERGEABLE".to_string()),
                 merge_state_status: Some("CLEAN".to_string()),
                 is_viewer_author: s.is_viewer_author,
+                merge_blockers: s.blockers.clone(),
             }
         })
         .collect()

--- a/src/model.rs
+++ b/src/model.rs
@@ -57,6 +57,60 @@ pub struct CiCheck {
     pub started_at_unix: Option<i64>,
 }
 
+/// Detailed information about why a PR cannot be merged.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct MergeBlockers {
+    /// PR has merge conflicts with the base branch.
+    pub has_conflicts: bool,
+    /// Number of approving reviews required by branch protection.
+    pub required_approvals: Option<u32>,
+    /// Current number of approving reviews.
+    pub current_approvals: u32,
+    /// Required status check contexts from branch protection.
+    pub required_checks: Vec<String>,
+    /// Subset of required checks that are failing or missing.
+    pub failing_required_checks: Vec<String>,
+    /// Base branch is ahead of the PR branch.
+    pub is_behind_base: bool,
+}
+
+impl MergeBlockers {
+    /// Returns true if there are no merge blockers.
+    pub fn is_clear(&self) -> bool {
+        !self.has_conflicts
+            && !self.is_behind_base
+            && self.failing_required_checks.is_empty()
+            && self
+                .required_approvals
+                .map(|r| self.current_approvals >= r)
+                .unwrap_or(true)
+    }
+
+    /// Returns a list of human-readable blocker descriptions.
+    pub fn to_descriptions(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        if self.has_conflicts {
+            out.push("Merge conflicts".to_string());
+        }
+        if self.is_behind_base {
+            out.push("Branch behind base".to_string());
+        }
+        if let Some(required) = self.required_approvals {
+            if self.current_approvals < required {
+                out.push(format!(
+                    "Approvals: {}/{} required",
+                    self.current_approvals, required
+                ));
+            }
+        }
+        if !self.failing_required_checks.is_empty() {
+            let checks = self.failing_required_checks.join(", ");
+            out.push(format!("Required checks failing: {}", checks));
+        }
+        out
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Pr {
     pub pr_key: String, // "{owner}/{repo}#{number}"
@@ -78,4 +132,5 @@ pub struct Pr {
     pub mergeable: Option<String>, // e.g. "MERGEABLE" | "CONFLICTING" | "UNKNOWN"
     pub merge_state_status: Option<String>, // e.g. "CLEAN" | "BLOCKED" | ...
     pub is_viewer_author: bool,    // true when this PR is authored by the signed-in user
+    pub merge_blockers: Option<MergeBlockers>,
 }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -119,6 +119,8 @@ pub fn load_cached(
             mergeable: row.mergeable.clone(),
             merge_state_status: row.merge_state_status.clone(),
             is_viewer_author: db_int_to_bool(row.author_is_viewer),
+            // Merge blockers are computed fresh from GraphQL, not cached
+            merge_blockers: None,
         };
         if !scope.matches(&pr) {
             continue;
@@ -520,6 +522,7 @@ mod tests {
             mergeable: None,
             merge_state_status: None,
             is_viewer_author: false,
+            merge_blockers: None,
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1144,6 +1144,44 @@ fn build_details_lines(
         ]));
     }
 
+    // Merge blockers section
+    if let Some(blockers) = &pr.pr.merge_blockers {
+        if (out.len() as u16) < inner_height {
+            out.push(Line::from(Span::raw("")));
+        }
+        if (out.len() as u16) < inner_height {
+            out.push(Line::from(Span::styled(
+                "MERGE BLOCKERS".to_string(),
+                Style::default()
+                    .fg(Color::Red)
+                    .add_modifier(Modifier::BOLD),
+            )));
+        }
+        if (out.len() as u16) < inner_height {
+            out.push(Line::from(Span::styled(
+                std::iter::repeat('─').take(iw).collect::<String>(),
+                Style::default().fg(Color::Gray),
+            )));
+        }
+
+        for desc in blockers.to_descriptions() {
+            if (out.len() as u16) >= inner_height {
+                break;
+            }
+            let (icon, color) = if desc.starts_with("Merge conflicts") || desc.contains("failing") {
+                ("❌", Color::Red)
+            } else if desc.starts_with("Branch behind") || desc.contains("Approvals") {
+                ("⚠️", Color::Yellow)
+            } else {
+                ("•", Color::Gray)
+            };
+            out.push(Line::from(vec![
+                Span::styled(format!("  {} ", icon), Style::default().fg(color)),
+                Span::styled(desc, Style::default().fg(color)),
+            ]));
+        }
+    }
+
     // CI checks list
     if (out.len() as u16) < inner_height {
         out.push(Line::from(Span::raw("")));


### PR DESCRIPTION
## Summary
Detect and display why a PR cannot be merged, showing exactly what's blocking it.

## Features
- Extend GraphQL queries to fetch branch protection rules and review counts
- Detect merge blockers:
  - **Merge conflicts** (PR has conflicts with base branch)
  - **Required approvals** (e.g., "Approvals: 1/2 required")
  - **Failing required checks** (checks required by branch protection that aren't green)
  - **Branch behind base** (needs rebase/merge from base)
- Display "MERGE BLOCKERS" section in details view (press Tab on a PR)
- Visual indicators: ❌ for critical issues, ⚠️ for warnings

## Demo
In demo mode, two PRs have sample merge blockers:
- windmill-labs/infra#317: conflicts + missing approval + failing required check
- honeycombio/otel-collector#77: needs approval + branch behind base

## Stacked on
- #5 (feat/pinned-prs)
- #4 (feat/config-file)