### PR TITLE
fix: handle null entries in commits.nodes GraphQL response

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -99,7 +99,7 @@ struct CommitNode {
 
 #[derive(Debug, serde::Deserialize)]
 struct Commits {
-    nodes: Option<Vec<CommitNode>>,
+    nodes: Option<Vec<Option<CommitNode>>>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -378,7 +378,7 @@ fn map_ci_checks(node: &PullRequestNode) -> Vec<CiCheck> {
     let Some(nodes) = &commits.nodes else {
         return Vec::new();
     };
-    let Some(first) = nodes.first() else {
+    let Some(first) = nodes.first().and_then(|n| n.as_ref()) else {
         return Vec::new();
     };
     let Some(commit) = &first.commit else {
@@ -493,7 +493,7 @@ fn derive_ci_state(rollup_state: Option<&str>, checks: &[CiCheck]) -> CiState {
 fn rollup_state(node: &PullRequestNode) -> Option<&str> {
     let commits = node.commits.as_ref()?;
     let nodes = commits.nodes.as_ref()?;
-    let first = nodes.first()?;
+    let first = nodes.first()?.as_ref()?;
     let commit = first.commit.as_ref()?;
     let rollup = commit.status_check_rollup.as_ref()?;
     rollup.state.as_deref()


### PR DESCRIPTION
GitHub's GraphQL API can return `null` elements inside `commits.nodes[]` for certain PRs. This caused serde deserialization to fail, which silently aborted the background refresh — resulting in an empty TUI with no PRs displayed.

The fix makes the `nodes` vec elements optional (`Option<CommitNode>`) and unwraps them safely at the two call sites.